### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AEGfycatHandler
 An simple Objective-C wrapper for the [Gfycat API](http://gfycat.com/api).
 
 ###Installation
-Just drag and drop the AEGfycatHandler folder into your Xcode project and import `AEGfycatViewerController.h` or `AEGfycatHandler.h` where needed. Alternatively, you can add `pod 'AEGfycatHandler'` to your Podfile and have Cocoapods import the files for you.
+Just drag and drop the AEGfycatHandler folder into your Xcode project and import `AEGfycatViewerController.h` or `AEGfycatHandler.h` where needed. Alternatively, you can add `pod 'AEGfycatHandler'` to your Podfile and have CocoaPods import the files for you.
 
 If you are supporting iOS 9.0+, you will also need to add the following to your Info.plist file in order for AEGfycatHandler to work correctly.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
